### PR TITLE
Added a working Verso Dockerfile that generates an image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:8
+
+ENV HOME /opt/sinopia/verso
+ENV REPO https://github.com/lcnetdev/verso.git
+
+RUN apt-get update && \ 
+    git clone $REPO $HOME
+
+WORKDIR $HOME
+
+RUN npm i npm@latest -g && \
+    cd $HOME && \
+    npm install -g
+
+CMD ["npm", "start"]


### PR DESCRIPTION
Allows Verso to built as a Docker Image.

Build verso:
`docker build -t ld4p/verso .`

Running in the foreground:
`docker run -p 8000:8000 ld4p/verso` 