### PR TITLE
Auth ldap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,89 @@
       "resolved": "https://registry.npmjs.org/@kyleshockey/object-assign-deep/-/object-assign-deep-0.4.2.tgz",
       "integrity": "sha1-hJAPDu/DcnmPR1G1JigwuCCJIuw="
     },
+    "@types/body-parser": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
+      "integrity": "sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==",
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/connect": {
+      "version": "3.4.32",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
+      "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/events": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
+      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA=="
+    },
+    "@types/express": {
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.16.0.tgz",
+      "integrity": "sha512-TtPEYumsmSTtTetAPXlJVf3kEqb6wZK0bZojpJQrnD/djV4q1oB6QQ8aKvKqwNPACoe02GNiy5zDzcYivR5Z2w==",
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.0.tgz",
+      "integrity": "sha512-lTeoCu5NxJU4OD9moCgm0ESZzweAx0YqsAcab6OB0EB3+As1OaHtKnaGJvcngQxYsi9UNv0abn4/DRavrRxt4w==",
+      "requires": {
+        "@types/events": "*",
+        "@types/node": "*",
+        "@types/range-parser": "*"
+      }
+    },
+    "@types/ldapjs": {
+      "version": "1.0.3",
+      "resolved": "http://registry.npmjs.org/@types/ldapjs/-/ldapjs-1.0.3.tgz",
+      "integrity": "sha512-FSj24s1WsFEfOy8taIKp2DokSZfFkjWYZb88AS5eDj3WTocZ+4DnHjhzrXEs048WQ5mfOLJXMOAnc0kSnHh5Lw==",
+      "requires": {
+        "@types/events": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/mime": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.0.tgz",
+      "integrity": "sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA=="
+    },
+    "@types/node": {
+      "version": "7.10.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.10.2.tgz",
+      "integrity": "sha512-RO4ig5taKmcrU4Rex8ojG1gpwFkjddzug9iPQSDvbewHN9vDpcFewevkaOK+KT+w1LeZnxbgOyfXwV4pxsQ4GQ=="
+    },
+    "@types/passport": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-0.4.7.tgz",
+      "integrity": "sha512-EePlxNYx5tf3n0yjdPXX0/zDOv0UCwjMyQo4UkWGlhHteNDItAj7TfDdLttSThVMKQz3uCW7lsGzMuml0f8g9Q==",
+      "requires": {
+        "@types/express": "*"
+      }
+    },
+    "@types/range-parser": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.2.tgz",
+      "integrity": "sha512-HtKGu+qG1NPvYe1z7ezLsyIaXYyi8SoAVqWDZgDQ8dLrsZvSzUNCwZyfX33uhWxL/SU0ZDQZ3nwZ0nimt507Kw=="
+    },
+    "@types/serve-static": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==",
+      "requires": {
+        "@types/express-serve-static-core": "*",
+        "@types/mime": "*"
+      }
+    },
     "JSONStream": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.3.tgz",
@@ -197,6 +280,14 @@
         "regenerator-runtime": "^0.11.0"
       }
     },
+    "backoff": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
+      "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
+      "requires": {
+        "precond": "0.2"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -309,6 +400,17 @@
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         }
+      }
+    },
+    "bunyan": {
+      "version": "1.8.12",
+      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz",
+      "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
+      "requires": {
+        "dtrace-provider": "~0.8",
+        "moment": "^2.10.6",
+        "mv": "~2",
+        "safe-json-stringify": "~1"
       }
     },
     "bytes": {
@@ -762,6 +864,15 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
       "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow=="
+    },
+    "dtrace-provider": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.7.tgz",
+      "integrity": "sha1-3JObTT4GIM/gwc2APQ0tftBP/QQ=",
+      "optional": true,
+      "requires": {
+        "nan": "^2.10.0"
+      }
     },
     "duplex": {
       "version": "1.0.0",
@@ -2059,6 +2170,50 @@
         "invert-kv": "^1.0.0"
       }
     },
+    "ldap-filter": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/ldap-filter/-/ldap-filter-0.2.2.tgz",
+      "integrity": "sha1-8rhCvguG2jNSeYUFsx68rlkNd9A=",
+      "requires": {
+        "assert-plus": "0.1.5"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+          "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA="
+        }
+      }
+    },
+    "ldapauth-fork": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ldapauth-fork/-/ldapauth-fork-4.0.2.tgz",
+      "integrity": "sha512-YoPHsyfV6L/4SO5EMi/Jk1xUMaY+ANlR4Yp+WIsqGkWOLPKkuzRYB4s/IsdKBeb3sdwVCw+q/YN9eoa1dXmQdA==",
+      "requires": {
+        "@types/ldapjs": "^1.0.0",
+        "@types/node": "^7.0.21",
+        "bcryptjs": "^2.4.0",
+        "ldapjs": "^1.0.1",
+        "lru-cache": "^4.0.2"
+      }
+    },
+    "ldapjs": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ldapjs/-/ldapjs-1.0.2.tgz",
+      "integrity": "sha1-VE/3Ayt7g8aPBwEyjZKXqmlDQPk=",
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "^1.0.0",
+        "backoff": "^2.5.0",
+        "bunyan": "^1.8.3",
+        "dashdash": "^1.14.0",
+        "dtrace-provider": "~0.8",
+        "ldap-filter": "0.2.2",
+        "once": "^1.4.0",
+        "vasync": "^1.6.4",
+        "verror": "^1.8.1"
+      }
+    },
     "ldtr": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/ldtr/-/ldtr-0.2.3.tgz",
@@ -2335,6 +2490,111 @@
         }
       }
     },
+    "loopback-component-passport": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/loopback-component-passport/-/loopback-component-passport-3.10.0.tgz",
+      "integrity": "sha1-rJ1tPt2HdCFuAeTzYbe77mvlHoQ=",
+      "requires": {
+        "passport": "^0.4.0",
+        "strong-globalize": "^4.1.1",
+        "underscore": "^1.9.1",
+        "uuid": "^3.2.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "debug": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "execa": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "invert-kv": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
+        },
+        "lcid": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+          "requires": {
+            "invert-kv": "^2.0.0"
+          }
+        },
+        "mem": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-4.0.0.tgz",
+          "integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
+          "requires": {
+            "map-age-cleaner": "^0.1.1",
+            "mimic-fn": "^1.0.0",
+            "p-is-promise": "^1.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        },
+        "os-locale": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.0.1.tgz",
+          "integrity": "sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==",
+          "requires": {
+            "execa": "^0.10.0",
+            "lcid": "^2.0.0",
+            "mem": "^4.0.0"
+          }
+        },
+        "strong-globalize": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/strong-globalize/-/strong-globalize-4.1.2.tgz",
+          "integrity": "sha512-2ks3/fuQy4B/AQDTAaEvTXYSqH4TWrv9VGlbZ4YujzijEJbIWbptF/9dO13duv87aRhWdM5ABEiTy7ZmnmBhdQ==",
+          "requires": {
+            "accept-language": "^3.0.18",
+            "debug": "^4.0.1",
+            "globalize": "^1.3.0",
+            "lodash": "^4.17.4",
+            "md5": "^2.2.1",
+            "mkdirp": "^0.5.1",
+            "os-locale": "^3.0.1",
+            "yamljs": "^0.3.0"
+          }
+        },
+        "underscore": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+          "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+        }
+      }
+    },
     "loopback-connector": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/loopback-connector/-/loopback-connector-4.4.0.tgz",
@@ -2575,14 +2835,14 @@
       }
     },
     "loopback-swagger": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/loopback-swagger/-/loopback-swagger-3.0.2.tgz",
-      "integrity": "sha1-4VBizGzTo/n+/XN6qD14QX1kgbs=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/loopback-swagger/-/loopback-swagger-3.0.3.tgz",
+      "integrity": "sha512-ly7t++ubK5eAuuKCNb4o7H+VHjO+cNm9PXMu1dfSG0r3uqKByGyxdhZ5ZrI4lt9RE5fDtGm1gA/25Up/Ce7SvQ==",
       "requires": {
         "async": "^1.4.2",
         "debug": "^2.2.0",
         "ejs": "^2.5.5",
-        "lodash": "^3.10.1",
+        "lodash": "^4.17.5",
         "strong-globalize": "^2.6.0",
         "underscore.string": "~2.3.3"
       },
@@ -2592,10 +2852,10 @@
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         },
         "strong-globalize": {
           "version": "2.10.0",
@@ -2621,17 +2881,12 @@
           },
           "dependencies": {
             "debug": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "version": "3.2.6",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+              "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
               "requires": {
-                "ms": "2.0.0"
+                "ms": "^2.1.1"
               }
-            },
-            "lodash": {
-              "version": "4.17.10",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-              "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
             }
           }
         },
@@ -2658,6 +2913,14 @@
       "requires": {
         "buildmail": "4.0.1",
         "libmime": "3.0.0"
+      }
+    },
+    "map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "requires": {
+        "p-defer": "^1.0.0"
       }
     },
     "marklogic": {
@@ -2780,6 +3043,12 @@
         }
       }
     },
+    "moment": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
+      "optional": true
+    },
     "mongodb": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.0.8.tgz",
@@ -2889,10 +3158,57 @@
         }
       }
     },
+    "mv": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+      "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
+      "optional": true,
+      "requires": {
+        "mkdirp": "~0.5.1",
+        "ncp": "~2.0.0",
+        "rimraf": "~2.4.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "optional": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "rimraf": {
+          "version": "2.4.5",
+          "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+          "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
+          "optional": true,
+          "requires": {
+            "glob": "^6.0.1"
+          }
+        }
+      }
+    },
+    "nan": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+      "optional": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+    },
+    "ncp": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
+      "optional": true
     },
     "negotiator": {
       "version": "0.6.1",
@@ -2904,6 +3220,11 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "nocache": {
       "version": "1.0.0",
@@ -3365,15 +3686,50 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
+    "p-is-promise": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
+    },
     "parseurl": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
       "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+    },
+    "passport": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.0.tgz",
+      "integrity": "sha1-xQlWkTR71a07XhgCOMORTRbwWBE=",
+      "requires": {
+        "passport-strategy": "1.x.x",
+        "pause": "0.0.1"
+      }
+    },
+    "passport-ldapauth": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/passport-ldapauth/-/passport-ldapauth-2.1.0.tgz",
+      "integrity": "sha512-znZdKW4f1bn4F8MRMzHog8fauSZictsC4GlOTs7ks4pL6HSSFuIZdxr/pnYkRJG+dmdLOqzOBXeFXZJIg4CFQg==",
+      "requires": {
+        "@types/node": "^7.0.23",
+        "@types/passport": "^0.4.6",
+        "ldapauth-fork": "^4.0.1",
+        "passport-strategy": "^1.0.0"
+      }
+    },
+    "passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -3400,6 +3756,11 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
     },
     "performance-now": {
       "version": "2.1.0",
@@ -3438,6 +3799,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/posix-getopt/-/posix-getopt-1.2.0.tgz",
       "integrity": "sha1-Su7rfa3mb8qKk2XdqfawBXQctiE="
+    },
+    "precond": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+      "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -3604,6 +3970,23 @@
         }
       }
     },
+    "requestretry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/requestretry/-/requestretry-2.0.2.tgz",
+      "integrity": "sha512-wBIylIEvvGHnFAYRXIKCARGzWxChn+mo7X3KjXPgtofB+c0ejcZFdZ5k6RFhBV+IOf80fkemcVuVdUKqovnj8A==",
+      "requires": {
+        "extend": "^3.0.2",
+        "lodash": "^4.17.10",
+        "when": "^3.7.7"
+      },
+      "dependencies": {
+        "extend": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        }
+      }
+    },
     "require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
@@ -3693,6 +4076,12 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "safe-json-stringify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
+      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
+      "optional": true
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -4269,6 +4658,29 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
+    "vasync": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/vasync/-/vasync-1.6.4.tgz",
+      "integrity": "sha1-3+k2Fq0OeugBszKp2Iv8XNyOHR8=",
+      "requires": {
+        "verror": "1.6.0"
+      },
+      "dependencies": {
+        "extsprintf": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz",
+          "integrity": "sha1-WtlGwi9bMrp/jNdCZxHG6KP8JSk="
+        },
+        "verror": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
+          "integrity": "sha1-fROyex+swuLakEBetepuW90lLqU=",
+          "requires": {
+            "extsprintf": "1.2.0"
+          }
+        }
+      }
+    },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -4283,6 +4695,11 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
       "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+    },
+    "when": {
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/when/-/when-3.7.8.tgz",
+      "integrity": "sha1-xxMLan6gRpPoQs3J56Hyqjmjn4I="
     },
     "which": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "posttest": "npm run lint && nsp check"
   },
   "dependencies": {
+    "body-parser": "^1.18.3",
     "compression": "^1.0.3",
     "cookie-parser": "^1.4.3",
     "cors": "^2.5.2",
@@ -21,9 +22,11 @@
     "loopback": "^3.0.0",
     "loopback-boot": "^2.6.5",
     "loopback-component-explorer": "^4.0.0",
+    "loopback-component-passport": "^3.10.0",
     "loopback-connector-mongodb": "^3.4.3",
     "loopback-ds-readonly-mixin": "^2.0.4",
     "marklogic": "^1.0.6",
+    "passport-ldapauth": "^2.1.0",
     "requestretry": "^2.0.2",
     "serve-favicon": "^2.0.1",
     "strong-error-handler": "^2.0.0",

--- a/server/boot/06-ldap-auth.js
+++ b/server/boot/06-ldap-auth.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const PassportConfigurator =
+  require('loopback-component-passport').PassportConfigurator;
+
+module.exports = function(app) {
+  const passportConfigurator = new PassportConfigurator(app);
+  const ttl = 3600;
+  const options = require('../providers.json')['ldap'];
+
+  passportConfigurator.init();
+  passportConfigurator.setupModels({
+    userModel: app.models.User,
+    userIdentityModel: app.models.UserIdentity,
+    userCredentialModel: app.models.UserCredential,
+  });
+  passportConfigurator.configureProvider('ldap', options);
+};

--- a/server/boot/07-admin-access.js
+++ b/server/boot/07-admin-access.js
@@ -78,13 +78,14 @@ module.exports = function(app) {
             if (emailRe.test(emailAttempt.email)) {
               return emailAttempt.email;
             } else {
-              console.log('Attempt failed '+ attempt+ ': Invalid email address, try again.');
-              throw Error ('FAIL');
-              //attempt++;
-              //if (attempt > 3){
-                console.err("Too many failed attempts");
-                //process.exit(1);
-              //} else {
+              console.log('Attempt failed ' + attempt + ': Invalid email \
+                address, try again.');
+              throw Error('FAIL');
+              // attempt++;
+              // if (attempt > 3){
+              console.err('Too many failed attempts');
+                // process.exit(1);
+              // } else {
               //  return emailAddr();
               // }
             }
@@ -127,7 +128,7 @@ module.exports = function(app) {
             console.log('Admin user created.');
           } catch (err) {
             console.warn('Unable to create admin user: ' + err);
-            //process.exit(1);
+            // process.exit(1);
           }
         })().catch(err => console.warn(err));
       }

--- a/server/model-config.json
+++ b/server/model-config.json
@@ -4,7 +4,8 @@
       "loopback/common/models",
       "loopback/server/models",
       "../common/models",
-      "./models"
+      "./models",
+      "../node_modules/loopback-component-passport/lib/models"
     ],
     "mixins": [
       "loopback/common/mixins",
@@ -35,6 +36,14 @@
   "Role": {
     "dataSource": "db",
     "public": false
+  },
+  "UserCredential": {
+    "dataSource": "db",
+    "public": true
+  },
+  "UserIdentity": {
+    "dataSource": "db",
+    "public": true
   },
   "bf": {
     "dataSource": "db",

--- a/server/providers.json
+++ b/server/providers.json
@@ -1,0 +1,26 @@
+{
+    "ldap": {
+      "provider": "ldap",
+      "authScheme": "ldap",
+      "module": "passport-ldapauth",
+      "authPath": "/verso/auth/ldap",
+      "failureRedirect": "/verso/auth/fail",
+      "session": true,
+      "json": true,
+      "profileAttributesFromLDAP": {
+        "login": "dn",
+        "username": "sn",
+        "displayName": "cn",
+        "email": "mail",
+        "externalId": "sAMAccountName"
+      },
+      "server":{
+        "url": "ldap://id-ad-test1.eastus.cloudapp.azure.com:389",
+        "bindDn": "cn=Charles Ledvina,cn=Users,dc=indexdata,dc=local",
+        "bindCredentials": "Pass@word1!",
+        "searchBase": "dc=indexdata,dc=local",
+        "searchFilter": "(CN={{username}})"
+      }
+    }
+  }
+  

--- a/server/providers.json
+++ b/server/providers.json
@@ -10,10 +10,11 @@
       "json": false,
       "profileAttributesFromLDAP": {
         "login": "dn",
-        "username": "sn",
-        "displayName": "cn",
+        "username": "sAMAccountName",
+        "displayName": "name",
         "email": "mail",
-        "externalId": "sAMAccountName"
+        "externalId": "sAMAccountName",
+        "role": "memberOf"
       },
       "server":{
         "url": "ldap://id-ad-test1.eastus.cloudapp.azure.com:389",

--- a/server/providers.json
+++ b/server/providers.json
@@ -4,9 +4,10 @@
       "authScheme": "ldap",
       "module": "passport-ldapauth",
       "authPath": "/verso/auth/ldap",
-      "failureRedirect": "/verso/auth/fail",
+      "failureRedirect": "/",
+      "successRedirect": "/",
       "session": true,
-      "json": true,
+      "json": false,
       "profileAttributesFromLDAP": {
         "login": "dn",
         "username": "sn",

--- a/server/providers.json
+++ b/server/providers.json
@@ -9,19 +9,19 @@
       "session": true,
       "json": false,
       "profileAttributesFromLDAP": {
-        "login": "dn",
+        "login": "sAMAccountName",
         "username": "sAMAccountName",
         "displayName": "name",
         "email": "mail",
         "externalId": "sAMAccountName",
-        "role": "memberOf"
+        "memberOf": "memberOf"
       },
       "server":{
         "url": "ldap://id-ad-test1.eastus.cloudapp.azure.com:389",
         "bindDn": "cn=Charles Ledvina,cn=Users,dc=indexdata,dc=local",
         "bindCredentials": "Pass@word1!",
         "searchBase": "dc=indexdata,dc=local",
-        "searchFilter": "(CN={{username}})"
+        "searchFilter": "(sAMAccountName={{username}})"
       }
     }
   }

--- a/server/server.js
+++ b/server/server.js
@@ -3,8 +3,12 @@
 require('dotenv').load();
 var loopback = require('loopback');
 var boot = require('loopback-boot');
+var bodyParser = require('body-parser');
 
 var app = module.exports = loopback();
+
+app.middleware('parse', bodyParser.json());
+app.middleware('parse', bodyParser.urlencoded({extended: true}));
 
 app.start = function() {
   // start the web server


### PR DESCRIPTION
I thought I create the pull request to show you where we are thus far.  This has been quite gnarly, but we are making some headway.  We setup a test LDAP account at Azure (which expires in a few days)-- but it works.  The problem is assigning roles-- this has to be done manually after a user is created by the passport ldap process.  Creating a user beforehand and assigning roles won't work because of the uniqueness requirements for username and password.

All of the LDAP server settings are contained in the providers.json file.  I haven't quite figured out a gracefully way of adding a certificate for ldaps connections.  I think we could read it from a file in 06-ldap-auth.js and then add the cert to the options object.  I haven't been able to successfully add the cert locally because of the host discrepancies-- this may not be an issue for you at LoC. 

Another issue:  passportConfigurator creates access_token and userId cookies.  The access_token is good enough to allow read/write access to loopback.  This cookie is not of the "HTTP only" flavor like the local login creates.  I don't know if this will be an issue, but it does expose the token to JS and could be easily manipulated by a nefarious user.  This module does not create a current_user cookie either.  I don't know if this cookie is actually needed or used.  It may be useful for adding usernames to bibframe descriptions-- I don't know.  We could create the cookie upon successful login.